### PR TITLE
SVE MapTilePresets

### DIFF
--- a/DynamicReflections/Framework/Managers/TileManager.cs
+++ b/DynamicReflections/Framework/Managers/TileManager.cs
@@ -40,13 +40,21 @@ namespace DynamicReflections.Framework.Managers
         {
             _mapTilePresets = new List<MapTilePresetTemplate>()
             {
+                // Vanilla map presets
                 new TownMapTilePreset(),
                 new BeachMapTilePreset(),
                 new BeachNightMarketMapTilePreset(),
                 new MountainMapTilePreset(),
                 new ForestMapTilePreset(),
                 new IslandNorthMapTilePreset(),
-                new IslandWestMapTilePreset()
+                new IslandWestMapTilePreset(),
+
+                // SVE map presets
+                new SVE_BeachMapTilePreset(),
+                new SVE_BeachNightMarketMapTilePreset(),
+                new SVE_ForestMapTilePreset(),
+                new SVE_MountainMapTilePreset(),
+                new SVE_TownMapTilePreset()
             };
         }
 

--- a/DynamicReflections/Framework/Models/MapTilePresets/Modded/SVE_BeachMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Modded/SVE_BeachMapTilePreset.cs
@@ -1,0 +1,163 @@
+﻿using DynamicReflections.Framework.Models.Reflections;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
+{
+    internal class SVE_BeachMapTilePreset : MapTilePresetTemplate
+    {
+        public override string MapName { get; } = "Beach";
+        public override List<string> RequiredModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
+
+        public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
+        {
+            new ReflectableMapObject("LonlyStone", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 26),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 26),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 26),
+
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 25),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 25),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 25),
+
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 24),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 24),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 24)
+            }),
+            new ReflectableMapObject("BrokenBeachBridge", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Back", x: 57, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 58, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 61, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 62, y: 13) { Offset = new Vector2(0f, 1.2f) },
+
+                //Needs a fixed bridge
+                new ReflectableMapTile(layerName: "Buildings", x: 59, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 60, y: 13) { Offset = new Vector2(0f, 1.2f) }
+            }),
+            new ReflectableMapObject("Street_Lamp_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 44, y: 34) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 44, y: 33) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Front", x: 44, y: 32) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Front", x: 44, y: 31) { Offset = new Vector2(0f, 2.5f) }
+            }),
+            new ReflectableMapObject("Street_Lamp_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 90, y: 38) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 90, y: 37) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Front", x: 90, y: 36) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Front", x: 90, y: 35) { Offset = new Vector2(0f, 2.5f) }
+            }),
+            // Made use of all used tiles for compt with bigger building retextures
+            new ReflectableMapObject("Willy_Fish_Shop", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 28, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 29, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 30, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 32, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 33, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 34, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 35, y: 33) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Buildings", x: 28, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 29, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 30, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 32, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 33, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 34, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 35, y: 32) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Buildings", x: 29, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 30, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 32, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 33, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 34, y: 31) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 27, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 32) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 27, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 31) { Offset = new Vector2(0f, 0f) },
+
+                // A Trash Can was added, swiched to AlwaysFront for said Tiles (Not for Festivals)
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 30) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 30) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 29) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 29) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 28) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 28) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 27) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 27) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 26) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 25) { Offset = new Vector2(0f, 0f) }
+            })
+        };
+    }
+}

--- a/DynamicReflections/Framework/Models/MapTilePresets/Modded/SVE_BeachNightMarketMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Modded/SVE_BeachNightMarketMapTilePreset.cs
@@ -1,0 +1,165 @@
+﻿using DynamicReflections.Framework.Models.Reflections;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
+{
+    internal class SVE_BeachNightMarketMapTilePreset : MapTilePresetTemplate
+    {
+        public override string MapName { get; } = "BeachNightMarket";
+        public override List<string> RequiredModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
+
+        public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
+        {
+            new ReflectableMapObject("LonlyStone", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 26),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 26),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 26),
+
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 25),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 25),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 25),
+
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 24),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 24),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 24)
+            }),
+            new ReflectableMapObject("BrokenBeachBridge", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Back", x: 57, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 58, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 61, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 62, y: 13) { Offset = new Vector2(0f, 1.2f) },
+
+                //Needs a fixed bridge
+                new ReflectableMapTile(layerName: "Buildings", x: 59, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 60, y: 13) { Offset = new Vector2(0f, 1.2f) }
+            }),
+            new ReflectableMapObject("Street_Lamp_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 44, y: 34) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 44, y: 33) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Front", x: 44, y: 32) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Front", x: 44, y: 31) { Offset = new Vector2(0f, 2.5f) },
+            }),
+            new ReflectableMapObject("Street_Lamp_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 90, y: 38) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 90, y: 37) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Front", x: 90, y: 36) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Front", x: 90, y: 35) { Offset = new Vector2(0f, 2.5f) },
+            }),
+            new ReflectableMapObject("Willy_Fish_Shop", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 28, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 29, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 30, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 32, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 33, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 34, y: 33) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 35, y: 33) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Buildings", x: 28, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 29, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 30, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 32, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 33, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 34, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 35, y: 32) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Buildings", x: 28, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 29, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 30, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 32, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 33, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 34, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 35, y: 31) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 27, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 32) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 27, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 31) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 27, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 30) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 27, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 29) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 27, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 28) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 27) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 26) { Offset = new Vector2(0f, 0f) },
+
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 25) { Offset = new Vector2(0f, 0f) }
+            })
+        };
+    }
+}

--- a/DynamicReflections/Framework/Models/MapTilePresets/Modded/SVE_ForestMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Modded/SVE_ForestMapTilePreset.cs
@@ -1,0 +1,183 @@
+﻿using DynamicReflections.Framework.Models.Reflections;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
+{
+    internal class SVE_ForestMapTilePreset : MapTilePresetTemplate
+    {
+        public override string MapName { get; } = "Forest";
+        public override List<string> RequiredModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
+
+        public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
+        {
+            // Doen't look that good
+            /*new ReflectableMapObject("Forest_North_WoodenPole_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 21) { Offset = new Vector2(0f, 1.2f) },
+            }),
+            new ReflectableMapObject("Forest_North_WoodenPole_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 24) { Offset = new Vector2(0f, 1.2f) },
+            }),
+            new ReflectableMapObject("Forest_North_WoodenPole_3", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 37, y: 20) { Offset = new Vector2(0f, 1.2f) },
+            }),
+            new ReflectableMapObject("Forest_North_WoodenPole_4", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 37, y: 26) { Offset = new Vector2(0f, 1.2f) },
+            }),*/
+            new ReflectableMapObject("Forest_North_StaticFir_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 29, y: 78),
+
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 77),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 76),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 76),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 76),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 75),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 75),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 75),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 74),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 74),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 74),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 73),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 73),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 73)
+            }),
+            new ReflectableMapObject("Forest_North_StaticPine_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 50, y: 86),
+
+                new ReflectableMapTile(layerName: "Front", x: 50, y: 85),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 84),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 84),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 84),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 83),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 83),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 83),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 82),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 82),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 82),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 81),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 81),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 81)
+            }),
+            new ReflectableMapObject("Forest_North_StaticPine_Tree_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 40, y: 66),
+
+                new ReflectableMapTile(layerName: "Front", x: 40, y: 65),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 64),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 64),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 64),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 63),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 63),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 63),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 62),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 62),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 62),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 61),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 61),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 61)
+            }),
+            new ReflectableMapObject("Forest_North_StaticPine_Tree_3", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 80, y: 54),
+
+                new ReflectableMapTile(layerName: "Front", x: 80, y: 53),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 52),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 52),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 52),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 51),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 51),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 51),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 50),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 50),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 50),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 49),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 49),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 49)
+            }),
+            new ReflectableMapObject("Forest_North_StaticBirch_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 95, y: 48),
+
+                new ReflectableMapTile(layerName: "Front", x: 95, y: 47),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 46),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 46),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 46),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 45),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 45),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 45),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 44),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 44),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 44),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 43),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 43),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 43)
+            }),
+            new ReflectableMapObject("Forest_North_StaticMaple_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 98, y: 46),
+
+                new ReflectableMapTile(layerName: "Front", x: 98, y: 45),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 44),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 44),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 44),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 43),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 43),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 43),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 42),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 42),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 42),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 41),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 41),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 41)
+            }),
+            new ReflectableMapObject("Forest_North_StaticBigBush_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 104, y: 36),
+                new ReflectableMapTile(layerName: "Buildings", x: 105, y: 36),
+                new ReflectableMapTile(layerName: "Buildings", x: 106, y: 36),
+
+                new ReflectableMapTile(layerName: "Front", x: 104, y: 35),
+                new ReflectableMapTile(layerName: "Front", x: 105, y: 35),
+                new ReflectableMapTile(layerName: "Front", x: 106, y: 35),
+
+                new ReflectableMapTile(layerName: "Front", x: 104, y: 34),
+                new ReflectableMapTile(layerName: "Front", x: 105, y: 34),
+                new ReflectableMapTile(layerName: "Front", x: 106, y: 34)
+            }),
+        };
+    }
+}

--- a/DynamicReflections/Framework/Models/MapTilePresets/Modded/SVE_MountainMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Modded/SVE_MountainMapTilePreset.cs
@@ -1,0 +1,150 @@
+﻿using DynamicReflections.Framework.Models.Reflections;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
+{
+    internal class SVE_MountainMapTilePreset : MapTilePresetTemplate
+    {
+        public override string MapName { get; } = "Mountain";
+        public override List<string> RequiredModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
+
+        public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
+        {
+            new ReflectableMapObject("Mountain_North_StaticPine_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 14),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 13),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 12),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 12),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 12),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 11),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 11),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 11),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 10),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 10),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 10),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 9),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 9),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 9)
+            }),
+            new ReflectableMapObject("Mountain_North_StaticFir_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 53, y: 13),
+
+                new ReflectableMapTile(layerName: "Front", x: 53, y: 12),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 11),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 11),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 11),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 10),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 10),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 10),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 9),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 9),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 9),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 8),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 8),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 8)
+            }),
+            //Silly me, looking for a cusror draw, but can it be done tho? (This does not work, the boulder is not a layer)
+            /*new ReflectableMapObject("Mountain_North_GlitteringBoulder", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 48, y: 13),
+                new ReflectableMapTile(layerName: "Buildings", x: 49, y: 13),
+
+                new ReflectableMapTile(layerName: "Buildings", x: 48, y: 12),
+                new ReflectableMapTile(layerName: "Buildings", x: 49, y: 12),
+
+                new ReflectableMapTile(layerName: "Buildings", x: 48, y: 11),
+                new ReflectableMapTile(layerName: "Buildings", x: 49, y: 11)
+            }),*/
+            new ReflectableMapObject("Mountain_North_Wood_Plank_Long", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 61, y: 21) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 62, y: 21) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 63, y: 21) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 64, y: 21) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 65, y: 21) { Offset = new Vector2(0f, 1.65f) }
+            }),
+            new ReflectableMapObject("Mountain_North_StaticFir_Tree_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 96, y: 5),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 4),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 3),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 3),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 3),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 2),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 2),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 2),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 1),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 1),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 1),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 0),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 0),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 0)
+            }),
+            new ReflectableMapObject("Mountain_North_StaticFir_Tree_3", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 101, y: 23),
+
+                new ReflectableMapTile(layerName: "Front", x: 101, y: 22),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 21),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 21),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 21),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 20),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 20),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 20),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 19),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 19),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 19),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 18),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 18),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 18)
+            }),
+            new ReflectableMapObject("Mountain_North_StaticPine_Tree_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 103, y: 32),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 31),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 30),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 30),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 30),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 29),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 29),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 29),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 28),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 28),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 28),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 27),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 27),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 27)
+            }),
+        };
+    }
+}

--- a/DynamicReflections/Framework/Models/MapTilePresets/Modded/SVE_TownMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Modded/SVE_TownMapTilePreset.cs
@@ -1,0 +1,202 @@
+﻿using DynamicReflections.Framework.Models.Reflections;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
+{
+    internal class SVE_TownMapTilePreset : MapTilePresetTemplate
+    {
+        public override string MapName { get; } = "Town";
+        public override List<string> RequiredModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
+
+        public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
+        {
+            new ReflectableMapObject("Town_SouthRiver_SpringTree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 25, y: 97),
+                new ReflectableMapTile(layerName: "Buildings", x: 26, y: 97),
+                new ReflectableMapTile(layerName: "Buildings", x: 25, y: 96),
+                new ReflectableMapTile(layerName: "Buildings", x: 26, y: 96),
+
+                new ReflectableMapTile(layerName: "Front", x: 25, y: 95),
+                new ReflectableMapTile(layerName: "Front", x: 26, y: 95),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 23, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 94),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 23, y: 93),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 93),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 93),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 93),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 93),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 93),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 23, y: 92),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 92),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 92),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 92),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 92),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 92),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 91),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 91),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 91),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 91)
+            }),
+            new ReflectableMapObject("Town_SouthRiver_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 43, y: 102),
+                new ReflectableMapTile(layerName: "Buildings", x: 44, y: 102),
+                new ReflectableMapTile(layerName: "Buildings", x: 43, y: 101),
+                new ReflectableMapTile(layerName: "Buildings", x: 44, y: 101),
+
+                new ReflectableMapTile(layerName: "Front", x: 43, y: 100),
+                new ReflectableMapTile(layerName: "Front", x: 44, y: 100),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 42, y: 99),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 43, y: 99),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 44, y: 99),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 99),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 42, y: 98),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 43, y: 98),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 44, y: 98),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 98),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 42, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 43, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 44, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 97),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 42, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 43, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 44, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 96)
+            }),
+            new ReflectableMapObject("Town_EastRiver_StaticBush_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 58, y: 99),
+                new ReflectableMapTile(layerName: "Buildings", x: 59, y: 99),
+                new ReflectableMapTile(layerName: "Buildings", x: 60, y: 99),
+
+                new ReflectableMapTile(layerName: "Front", x: 58, y: 98),
+                new ReflectableMapTile(layerName: "Front", x: 59, y: 98),
+                new ReflectableMapTile(layerName: "Front", x: 60, y: 98),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 58, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 59, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 60, y: 97)
+            }),
+            new ReflectableMapObject("Town_EastRiver_Bridge_Under_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Back", x: 75, y: 95) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 76, y: 95) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 77, y: 95) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 78, y: 95) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 79, y: 95) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 80, y: 95) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 81, y: 95) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 82, y: 95) { Offset = new Vector2(0f, 2.2f) }
+            }),
+            new ReflectableMapObject("Town_EastRiver_Bridge_Rail_1", new List<ReflectableMapTile>()
+            {
+                /*
+                new ReflectableMapTile(layerName: "Front", x: 75, y: 95) { Offset = new Vector2(0f, 2.9f) },
+                new ReflectableMapTile(layerName: "Front", x: 76, y: 95) { Offset = new Vector2(0f, 2.9f) },
+                new ReflectableMapTile(layerName: "Front", x: 77, y: 95) { Offset = new Vector2(0f, 2.9f) },
+                new ReflectableMapTile(layerName: "Front", x: 78, y: 95) { Offset = new Vector2(0f, 2.9f) },
+                new ReflectableMapTile(layerName: "Front", x: 79, y: 95) { Offset = new Vector2(0f, 2.9f) },
+                new ReflectableMapTile(layerName: "Front", x: 80, y: 95) { Offset = new Vector2(0f, 2.9f) },
+                new ReflectableMapTile(layerName: "Front", x: 81, y: 95) { Offset = new Vector2(0f, 2.9f) },
+                new ReflectableMapTile(layerName: "Front", x: 82, y: 95) { Offset = new Vector2(0f, 2.9f) }
+                */
+                
+                new ReflectableMapTile(layerName: "Buildings", x: 75, y: 96) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 76, y: 96) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 77, y: 96) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 78, y: 96) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 79, y: 96) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 80, y: 96) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 81, y: 96) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 82, y: 96) { Offset = new Vector2(0f, 1.6f) },
+
+            }),
+            new ReflectableMapObject("Town_SouthRiver_SpringTree_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 88, y: 100),
+                new ReflectableMapTile(layerName: "Buildings", x: 89, y: 100),
+                new ReflectableMapTile(layerName: "Buildings", x: 88, y: 99),
+                new ReflectableMapTile(layerName: "Buildings", x: 89, y: 99),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 98),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 98),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 86, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 91, y: 97),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 86, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 91, y: 96),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 86, y: 95),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 95),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 95),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 95),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 95),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 91, y: 95),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 94)
+            }),
+            new ReflectableMapObject("Town_EastRiver_Bridge_Under_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Back", x: 70, y: 54) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 71, y: 54) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 72, y: 54) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 73, y: 54) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 74, y: 54) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 75, y: 54) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 76, y: 54) { Offset = new Vector2(0f, 2.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 77, y: 54) { Offset = new Vector2(0f, 2.2f) }
+            }),
+            new ReflectableMapObject("Town_EastRiver_Bridge_Rail_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 70, y: 55) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 71, y: 55) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 72, y: 55) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 73, y: 55) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 74, y: 55) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 75, y: 55) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 76, y: 55) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 77, y: 55) { Offset = new Vector2(0f, 1.6f) },
+
+            }),
+            new ReflectableMapObject("Town_EastRiver_Wood_Plank", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 92, y: 13) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 93, y: 13) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 94, y: 13) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 95, y: 13) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 96, y: 13) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 97, y: 13) { Offset = new Vector2(0f, 1.6f) }
+            }),
+        };
+    }
+}

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachMapTilePreset.cs
@@ -13,21 +13,46 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
         public override string MapName { get; } = "Beach";
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
-            /*
+            new ReflectableMapObject("LonlyStone", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 26),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 26),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 26),
+
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 25),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 25),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 25),
+
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 24),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 24),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 24)
+            }),
+            new ReflectableMapObject("BrokenBeachBridge", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Back", x: 57, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 58, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 61, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 62, y: 13) { Offset = new Vector2(0f, 1.2f) },
+
+                //Needs a fixed bridge
+                new ReflectableMapTile(layerName: "Buildings", x: 59, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 60, y: 13) { Offset = new Vector2(0f, 1.2f) }
+            }),
             new ReflectableMapObject("Street_Lamp_1", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 44, y: 34) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 44, y: 33) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Front", x: 44, y: 32) { Offset = new Vector2(0f, 2.5f) },
-                new ReflectableMapTile(layerName: "Front", x: 44, y: 31) { Offset = new Vector2(0f, 2.5f) },
+                new ReflectableMapTile(layerName: "Front", x: 44, y: 31) { Offset = new Vector2(0f, 2.5f) }
             }),
             new ReflectableMapObject("Street_Lamp_2", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 90, y: 38) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 90, y: 37) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Front", x: 90, y: 36) { Offset = new Vector2(0f, 2.5f) },
-                new ReflectableMapTile(layerName: "Front", x: 90, y: 35) { Offset = new Vector2(0f, 2.5f) },
-            })
+                new ReflectableMapTile(layerName: "Front", x: 90, y: 35) { Offset = new Vector2(0f, 2.5f) }
+            }),
+            // Made use of all used tiles for compt with bigger building retextures
             new ReflectableMapObject("Willy_Fish_Shop", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 28, y: 33) { Offset = new Vector2(0f, 0f) },
@@ -48,41 +73,27 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Buildings", x: 34, y: 32) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 35, y: 32) { Offset = new Vector2(0f, 0f) },
 
-                new ReflectableMapTile(layerName: "Buildings", x: 28, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 29, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 30, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 31, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 32, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 33, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 34, y: 31) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 35, y: 31) { Offset = new Vector2(0f, 0f) },
 
                 new ReflectableMapTile(layerName: "Front", x: 27, y: 32) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 28, y: 32) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 29, y: 32) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 30, y: 32) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 31, y: 32) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 32, y: 32) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 33, y: 32) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 34, y: 32) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 35, y: 32) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 36, y: 32) { Offset = new Vector2(0f, 0f) },
 
                 new ReflectableMapTile(layerName: "Front", x: 27, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 28, y: 31) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 29, y: 31) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 30, y: 31) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 31, y: 31) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 32, y: 31) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 33, y: 31) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 34, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 36, y: 31) { Offset = new Vector2(0f, 0f) },
 
-                new ReflectableMapTile(layerName: "Front", x: 27, y: 30) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 28, y: 30) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 29, y: 30) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 30, y: 30) { Offset = new Vector2(0f, 0f) },
+                // A Trash Can was added, swiched to AlwaysFront for said Tiles (Not for Festivals)
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 30) { Offset = new Vector2(0f, 0f) },
+
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 30) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 30) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 30) { Offset = new Vector2(0f, 0f) },
@@ -90,10 +101,11 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 30) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 36, y: 30) { Offset = new Vector2(0f, 0f) },
 
-                new ReflectableMapTile(layerName: "Front", x: 27, y: 29) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 28, y: 29) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 29, y: 29) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 30, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 29) { Offset = new Vector2(0f, 0f) },
+
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 29) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 29) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 29) { Offset = new Vector2(0f, 0f) },
@@ -101,10 +113,11 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 29) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 36, y: 29) { Offset = new Vector2(0f, 0f) },
 
-                new ReflectableMapTile(layerName: "Front", x: 27, y: 28) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 28, y: 28) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 29, y: 28) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 30, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 28) { Offset = new Vector2(0f, 0f) },
+
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 28) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 28) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 28) { Offset = new Vector2(0f, 0f) },
@@ -112,15 +125,18 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 28) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 36, y: 28) { Offset = new Vector2(0f, 0f) },
 
-                new ReflectableMapTile(layerName: "Front", x: 28, y: 27) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 29, y: 27) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 30, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 27) { Offset = new Vector2(0f, 0f) },
+
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 27) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 27) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 27) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 34, y: 27) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 27) { Offset = new Vector2(0f, 0f) },
 
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 26) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 29, y: 26) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 30, y: 26) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 26) { Offset = new Vector2(0f, 0f) },
@@ -128,13 +144,18 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 26) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 34, y: 26) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 26) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 26) { Offset = new Vector2(0f, 0f) },
 
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 30, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 36, y: 25) { Offset = new Vector2(0f, 0f) }
             })
-            */
         };
     }
 }

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachMapTilePreset.cs
@@ -13,46 +13,21 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
         public override string MapName { get; } = "Beach";
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
-            new ReflectableMapObject("LonlyStone", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Front", x: 4, y: 26),
-                new ReflectableMapTile(layerName: "Front", x: 5, y: 26),
-                new ReflectableMapTile(layerName: "Front", x: 6, y: 26),
-
-                new ReflectableMapTile(layerName: "Front", x: 4, y: 25),
-                new ReflectableMapTile(layerName: "Front", x: 5, y: 25),
-                new ReflectableMapTile(layerName: "Front", x: 6, y: 25),
-
-                new ReflectableMapTile(layerName: "Front", x: 4, y: 24),
-                new ReflectableMapTile(layerName: "Front", x: 5, y: 24),
-                new ReflectableMapTile(layerName: "Front", x: 6, y: 24)
-            }),
-            new ReflectableMapObject("BrokenBeachBridge", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Back", x: 57, y: 13) { Offset = new Vector2(0f, 1.2f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 58, y: 13) { Offset = new Vector2(0f, 1.2f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 61, y: 13) { Offset = new Vector2(0f, 1.2f) },
-                new ReflectableMapTile(layerName: "Back", x: 62, y: 13) { Offset = new Vector2(0f, 1.2f) },
-
-                //Needs a fixed bridge
-                new ReflectableMapTile(layerName: "Buildings", x: 59, y: 13) { Offset = new Vector2(0f, 1.2f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 60, y: 13) { Offset = new Vector2(0f, 1.2f) }
-            }),
+            /*
             new ReflectableMapObject("Street_Lamp_1", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 44, y: 34) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 44, y: 33) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Front", x: 44, y: 32) { Offset = new Vector2(0f, 2.5f) },
-                new ReflectableMapTile(layerName: "Front", x: 44, y: 31) { Offset = new Vector2(0f, 2.5f) }
+                new ReflectableMapTile(layerName: "Front", x: 44, y: 31) { Offset = new Vector2(0f, 2.5f) },
             }),
             new ReflectableMapObject("Street_Lamp_2", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 90, y: 38) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 90, y: 37) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Front", x: 90, y: 36) { Offset = new Vector2(0f, 2.5f) },
-                new ReflectableMapTile(layerName: "Front", x: 90, y: 35) { Offset = new Vector2(0f, 2.5f) }
-            }),
-            // Made use of all used tiles for compt with bigger building retextures
+                new ReflectableMapTile(layerName: "Front", x: 90, y: 35) { Offset = new Vector2(0f, 2.5f) },
+            })
             new ReflectableMapObject("Willy_Fish_Shop", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 28, y: 33) { Offset = new Vector2(0f, 0f) },
@@ -73,27 +48,41 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Buildings", x: 34, y: 32) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 35, y: 32) { Offset = new Vector2(0f, 0f) },
 
+                new ReflectableMapTile(layerName: "Buildings", x: 28, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 29, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 30, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 31, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 32, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 33, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 34, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 35, y: 31) { Offset = new Vector2(0f, 0f) },
 
                 new ReflectableMapTile(layerName: "Front", x: 27, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 32) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 35, y: 32) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 36, y: 32) { Offset = new Vector2(0f, 0f) },
 
                 new ReflectableMapTile(layerName: "Front", x: 27, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 28, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 31, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 32, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 31) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 34, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 31) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 36, y: 31) { Offset = new Vector2(0f, 0f) },
 
-                // A Trash Can was added, swiched to AlwaysFront for said Tiles (Not for Festivals)
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 30) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 30) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 30) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 30) { Offset = new Vector2(0f, 0f) },
-
+                new ReflectableMapTile(layerName: "Front", x: 27, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 30) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 30) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 30) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 30) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 30) { Offset = new Vector2(0f, 0f) },
@@ -101,11 +90,10 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 30) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 36, y: 30) { Offset = new Vector2(0f, 0f) },
 
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 29) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 29) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 29) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 29) { Offset = new Vector2(0f, 0f) },
-
+                new ReflectableMapTile(layerName: "Front", x: 27, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 29) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 29) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 29) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 29) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 29) { Offset = new Vector2(0f, 0f) },
@@ -113,11 +101,10 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 29) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 36, y: 29) { Offset = new Vector2(0f, 0f) },
 
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 28) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 28) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 28) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 28) { Offset = new Vector2(0f, 0f) },
-
+                new ReflectableMapTile(layerName: "Front", x: 27, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 28) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 28) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 28) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 28) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 28) { Offset = new Vector2(0f, 0f) },
@@ -125,18 +112,15 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 28) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 36, y: 28) { Offset = new Vector2(0f, 0f) },
 
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 27) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 27) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 27) { Offset = new Vector2(0f, 0f) },
-
+                new ReflectableMapTile(layerName: "Front", x: 28, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 27) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 30, y: 27) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 27) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 27) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 27) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 34, y: 27) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 27) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 36, y: 27) { Offset = new Vector2(0f, 0f) },
 
-                new ReflectableMapTile(layerName: "Front", x: 28, y: 26) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 29, y: 26) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 30, y: 26) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 26) { Offset = new Vector2(0f, 0f) },
@@ -144,18 +128,13 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 26) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 34, y: 26) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 35, y: 26) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 36, y: 26) { Offset = new Vector2(0f, 0f) },
 
-                new ReflectableMapTile(layerName: "Front", x: 28, y: 25) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 29, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 30, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 33, y: 25) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 34, y: 25) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 35, y: 25) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 36, y: 25) { Offset = new Vector2(0f, 0f) }
             })
+            */
         };
     }
 }

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachMapTilePreset.cs
@@ -11,6 +11,8 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
     internal class BeachMapTilePreset : MapTilePresetTemplate
     {
         public override string MapName { get; } = "Beach";
+        public override List<string> SkipWithModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
+
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
             /*

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachNightMarketMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachNightMarketMapTilePreset.cs
@@ -13,6 +13,31 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
         public override string MapName { get; } = "BeachNightMarket";
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
+            new ReflectableMapObject("LonlyStone", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 26),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 26),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 26),
+
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 25),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 25),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 25),
+
+                new ReflectableMapTile(layerName: "Front", x: 4, y: 24),
+                new ReflectableMapTile(layerName: "Front", x: 5, y: 24),
+                new ReflectableMapTile(layerName: "Front", x: 6, y: 24)
+            }),
+            new ReflectableMapObject("BrokenBeachBridge", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Back", x: 57, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 58, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 61, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Back", x: 62, y: 13) { Offset = new Vector2(0f, 1.2f) },
+
+                //Needs a fixed bridge
+                new ReflectableMapTile(layerName: "Buildings", x: 59, y: 13) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 60, y: 13) { Offset = new Vector2(0f, 1.2f) }
+            }),
             new ReflectableMapObject("Street_Lamp_1", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 44, y: 34) { Offset = new Vector2(0f, 2.5f) },
@@ -26,8 +51,7 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Buildings", x: 90, y: 37) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Front", x: 90, y: 36) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Front", x: 90, y: 35) { Offset = new Vector2(0f, 2.5f) },
-            })
-            /*
+            }),
             new ReflectableMapObject("Willy_Fish_Shop", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 28, y: 33) { Offset = new Vector2(0f, 0f) },
@@ -132,9 +156,8 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Front", x: 30, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 25) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 33, y: 25) { Offset = new Vector2(0f, 0f) },
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 25) { Offset = new Vector2(0f, 0f) }
             })
-            */
         };
     }
 }

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachNightMarketMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachNightMarketMapTilePreset.cs
@@ -11,6 +11,8 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
     internal class BeachNightMarketMapTilePreset : MapTilePresetTemplate
     {
         public override string MapName { get; } = "BeachNightMarket";
+        public override List<string> SkipWithModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
+
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
             new ReflectableMapObject("Street_Lamp_1", new List<ReflectableMapTile>()

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachNightMarketMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/BeachNightMarketMapTilePreset.cs
@@ -13,31 +13,6 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
         public override string MapName { get; } = "BeachNightMarket";
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
-            new ReflectableMapObject("LonlyStone", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Front", x: 4, y: 26),
-                new ReflectableMapTile(layerName: "Front", x: 5, y: 26),
-                new ReflectableMapTile(layerName: "Front", x: 6, y: 26),
-
-                new ReflectableMapTile(layerName: "Front", x: 4, y: 25),
-                new ReflectableMapTile(layerName: "Front", x: 5, y: 25),
-                new ReflectableMapTile(layerName: "Front", x: 6, y: 25),
-
-                new ReflectableMapTile(layerName: "Front", x: 4, y: 24),
-                new ReflectableMapTile(layerName: "Front", x: 5, y: 24),
-                new ReflectableMapTile(layerName: "Front", x: 6, y: 24)
-            }),
-            new ReflectableMapObject("BrokenBeachBridge", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Back", x: 57, y: 13) { Offset = new Vector2(0f, 1.2f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 58, y: 13) { Offset = new Vector2(0f, 1.2f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 61, y: 13) { Offset = new Vector2(0f, 1.2f) },
-                new ReflectableMapTile(layerName: "Back", x: 62, y: 13) { Offset = new Vector2(0f, 1.2f) },
-
-                //Needs a fixed bridge
-                new ReflectableMapTile(layerName: "Buildings", x: 59, y: 13) { Offset = new Vector2(0f, 1.2f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 60, y: 13) { Offset = new Vector2(0f, 1.2f) }
-            }),
             new ReflectableMapObject("Street_Lamp_1", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 44, y: 34) { Offset = new Vector2(0f, 2.5f) },
@@ -51,7 +26,8 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Buildings", x: 90, y: 37) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Front", x: 90, y: 36) { Offset = new Vector2(0f, 2.5f) },
                 new ReflectableMapTile(layerName: "Front", x: 90, y: 35) { Offset = new Vector2(0f, 2.5f) },
-            }),
+            })
+            /*
             new ReflectableMapObject("Willy_Fish_Shop", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 28, y: 33) { Offset = new Vector2(0f, 0f) },
@@ -156,8 +132,9 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Front", x: 30, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 31, y: 25) { Offset = new Vector2(0f, 0f) },
                 new ReflectableMapTile(layerName: "Front", x: 32, y: 25) { Offset = new Vector2(0f, 0f) },
-                new ReflectableMapTile(layerName: "Front", x: 33, y: 25) { Offset = new Vector2(0f, 0f) }
+                new ReflectableMapTile(layerName: "Front", x: 33, y: 25) { Offset = new Vector2(0f, 0f) },
             })
+            */
         };
     }
 }

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/ForestMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/ForestMapTilePreset.cs
@@ -11,24 +11,170 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
     internal class ForestMapTilePreset : MapTilePresetTemplate
     {
         public override string MapName { get; } = "Forest";
-        public override List<string> SkipWithModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
-            new ReflectableMapObject("Forest_North_Wood_Plank_Short", new List<ReflectableMapTile>()
+            // Doen't look that good
+            /*new ReflectableMapObject("Forest_North_WoodenPole_1", new List<ReflectableMapTile>()
             {
-                new ReflectableMapTile(layerName: "Buildings", x: 62, y: 70) { Offset = new Vector2(0f, 1.65f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 63, y: 70) { Offset = new Vector2(0f, 1.65f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 64, y: 70) { Offset = new Vector2(0f, 1.65f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 65, y: 70) { Offset = new Vector2(0f, 1.65f) }
+                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 21) { Offset = new Vector2(0f, 1.2f) },
             }),
-            new ReflectableMapObject("Forest_North_Wood_Plank_Long", new List<ReflectableMapTile>()
+            new ReflectableMapObject("Forest_North_WoodenPole_2", new List<ReflectableMapTile>()
             {
-                new ReflectableMapTile(layerName: "Buildings", x: 77, y: 49) { Offset = new Vector2(0f, 1.65f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 78, y: 49) { Offset = new Vector2(0f, 1.65f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 79, y: 49) { Offset = new Vector2(0f, 1.65f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 80, y: 49) { Offset = new Vector2(0f, 1.65f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 81, y: 49) { Offset = new Vector2(0f, 1.65f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 82, y: 49) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 24) { Offset = new Vector2(0f, 1.2f) },
+            }),
+            new ReflectableMapObject("Forest_North_WoodenPole_3", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 37, y: 20) { Offset = new Vector2(0f, 1.2f) },
+            }),
+            new ReflectableMapObject("Forest_North_WoodenPole_4", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 37, y: 26) { Offset = new Vector2(0f, 1.2f) },
+            }),*/
+            new ReflectableMapObject("Forest_North_StaticFir_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 29, y: 78),
+
+                new ReflectableMapTile(layerName: "Front", x: 29, y: 77),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 76),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 76),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 76),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 75),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 75),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 75),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 74),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 74),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 74),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 73),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 73),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 73)
+            }),
+            new ReflectableMapObject("Forest_North_StaticPine_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 50, y: 86),
+
+                new ReflectableMapTile(layerName: "Front", x: 50, y: 85),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 84),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 84),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 84),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 83),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 83),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 83),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 82),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 82),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 82),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 81),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 81),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 81)
+            }),
+            new ReflectableMapObject("Forest_North_StaticPine_Tree_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 40, y: 66),
+
+                new ReflectableMapTile(layerName: "Front", x: 40, y: 65),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 64),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 64),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 64),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 63),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 63),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 63),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 62),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 62),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 62),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 61),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 61),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 61)
+            }),
+            new ReflectableMapObject("Forest_North_StaticPine_Tree_3", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 80, y: 54),
+
+                new ReflectableMapTile(layerName: "Front", x: 80, y: 53),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 52),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 52),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 52),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 51),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 51),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 51),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 50),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 50),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 50),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 49),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 49),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 49)
+            }),
+            new ReflectableMapObject("Forest_North_StaticBirch_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 95, y: 48),
+
+                new ReflectableMapTile(layerName: "Front", x: 95, y: 47),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 46),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 46),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 46),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 45),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 45),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 45),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 44),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 44),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 44),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 43),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 43),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 43)
+            }),
+            new ReflectableMapObject("Forest_North_StaticMaple_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 98, y: 46),
+
+                new ReflectableMapTile(layerName: "Front", x: 98, y: 45),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 44),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 44),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 44),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 43),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 43),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 43),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 42),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 42),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 42),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 41),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 41),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 41)
+            }),
+            new ReflectableMapObject("Forest_North_StaticBigBush_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 104, y: 36),
+                new ReflectableMapTile(layerName: "Buildings", x: 105, y: 36),
+                new ReflectableMapTile(layerName: "Buildings", x: 106, y: 36),
+
+                new ReflectableMapTile(layerName: "Front", x: 104, y: 35),
+                new ReflectableMapTile(layerName: "Front", x: 105, y: 35),
+                new ReflectableMapTile(layerName: "Front", x: 106, y: 35),
+
+                new ReflectableMapTile(layerName: "Front", x: 104, y: 34),
+                new ReflectableMapTile(layerName: "Front", x: 105, y: 34),
+                new ReflectableMapTile(layerName: "Front", x: 106, y: 34)
             }),
         };
     }

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/ForestMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/ForestMapTilePreset.cs
@@ -11,170 +11,24 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
     internal class ForestMapTilePreset : MapTilePresetTemplate
     {
         public override string MapName { get; } = "Forest";
+        public override List<string> SkipWithModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
-            // Doen't look that good
-            /*new ReflectableMapObject("Forest_North_WoodenPole_1", new List<ReflectableMapTile>()
+            new ReflectableMapObject("Forest_North_Wood_Plank_Short", new List<ReflectableMapTile>()
             {
-                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 21) { Offset = new Vector2(0f, 1.2f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 62, y: 70) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 63, y: 70) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 64, y: 70) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 65, y: 70) { Offset = new Vector2(0f, 1.65f) }
             }),
-            new ReflectableMapObject("Forest_North_WoodenPole_2", new List<ReflectableMapTile>()
+            new ReflectableMapObject("Forest_North_Wood_Plank_Long", new List<ReflectableMapTile>()
             {
-                new ReflectableMapTile(layerName: "Buildings", x: 31, y: 24) { Offset = new Vector2(0f, 1.2f) },
-            }),
-            new ReflectableMapObject("Forest_North_WoodenPole_3", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 37, y: 20) { Offset = new Vector2(0f, 1.2f) },
-            }),
-            new ReflectableMapObject("Forest_North_WoodenPole_4", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 37, y: 26) { Offset = new Vector2(0f, 1.2f) },
-            }),*/
-            new ReflectableMapObject("Forest_North_StaticFir_Tree_1", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 29, y: 78),
-
-                new ReflectableMapTile(layerName: "Front", x: 29, y: 77),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 76),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 76),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 76),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 75),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 75),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 75),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 74),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 74),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 74),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 73),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 29, y: 73),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 30, y: 73)
-            }),
-            new ReflectableMapObject("Forest_North_StaticPine_Tree_1", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 50, y: 86),
-
-                new ReflectableMapTile(layerName: "Front", x: 50, y: 85),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 84),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 84),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 84),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 83),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 83),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 83),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 82),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 82),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 82),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 49, y: 81),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 50, y: 81),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 51, y: 81)
-            }),
-            new ReflectableMapObject("Forest_North_StaticPine_Tree_2", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 40, y: 66),
-
-                new ReflectableMapTile(layerName: "Front", x: 40, y: 65),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 64),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 64),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 64),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 63),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 63),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 63),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 62),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 62),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 62),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 39, y: 61),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 40, y: 61),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 41, y: 61)
-            }),
-            new ReflectableMapObject("Forest_North_StaticPine_Tree_3", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 80, y: 54),
-
-                new ReflectableMapTile(layerName: "Front", x: 80, y: 53),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 52),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 52),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 52),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 51),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 51),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 51),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 50),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 50),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 50),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 79, y: 49),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 80, y: 49),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 81, y: 49)
-            }),
-            new ReflectableMapObject("Forest_North_StaticBirch_Tree_1", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 95, y: 48),
-
-                new ReflectableMapTile(layerName: "Front", x: 95, y: 47),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 46),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 46),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 46),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 45),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 45),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 45),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 44),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 44),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 44),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 94, y: 43),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 43),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 43)
-            }),
-            new ReflectableMapObject("Forest_North_StaticMaple_Tree_1", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 98, y: 46),
-
-                new ReflectableMapTile(layerName: "Front", x: 98, y: 45),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 44),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 44),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 44),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 43),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 43),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 43),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 42),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 42),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 42),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 41),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 98, y: 41),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 99, y: 41)
-            }),
-            new ReflectableMapObject("Forest_North_StaticBigBush_1", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 104, y: 36),
-                new ReflectableMapTile(layerName: "Buildings", x: 105, y: 36),
-                new ReflectableMapTile(layerName: "Buildings", x: 106, y: 36),
-
-                new ReflectableMapTile(layerName: "Front", x: 104, y: 35),
-                new ReflectableMapTile(layerName: "Front", x: 105, y: 35),
-                new ReflectableMapTile(layerName: "Front", x: 106, y: 35),
-
-                new ReflectableMapTile(layerName: "Front", x: 104, y: 34),
-                new ReflectableMapTile(layerName: "Front", x: 105, y: 34),
-                new ReflectableMapTile(layerName: "Front", x: 106, y: 34)
+                new ReflectableMapTile(layerName: "Buildings", x: 77, y: 49) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 78, y: 49) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 79, y: 49) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 80, y: 49) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 81, y: 49) { Offset = new Vector2(0f, 1.65f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 82, y: 49) { Offset = new Vector2(0f, 1.65f) },
             }),
         };
     }

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/ForestMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/ForestMapTilePreset.cs
@@ -12,6 +12,7 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
     {
         public override string MapName { get; } = "Forest";
         public override List<string> SkipWithModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
+
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
             new ReflectableMapObject("Forest_North_Wood_Plank_Short", new List<ReflectableMapTile>()

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/MountainMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/MountainMapTilePreset.cs
@@ -13,13 +13,62 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
         public override string MapName { get; } = "Mountain";
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
-            new ReflectableMapObject("Mountain_North_Wood_Plank_Short", new List<ReflectableMapTile>()
+            new ReflectableMapObject("Mountain_North_StaticPine_Tree_1", new List<ReflectableMapTile>()
             {
-                new ReflectableMapTile(layerName: "Buildings", x: 46, y: 7) { Offset = new Vector2(0f, 1.6f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 47, y: 7) { Offset = new Vector2(0f, 1.6f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 48, y: 7) { Offset = new Vector2(0f, 1.6f) },
-                new ReflectableMapTile(layerName: "Buildings", x: 49, y: 7) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 14),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 13),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 12),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 12),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 12),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 11),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 11),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 11),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 10),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 10),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 10),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 9),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 9),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 9)
             }),
+            new ReflectableMapObject("Mountain_North_StaticFir_Tree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 53, y: 13),
+
+                new ReflectableMapTile(layerName: "Front", x: 53, y: 12),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 11),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 11),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 11),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 10),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 10),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 10),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 9),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 9),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 9),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 8),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 8),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 8)
+            }),
+            //Silly me, looking for a cusror draw, but can it be done tho? (This does not work, the boulder is not a layer)
+            /*new ReflectableMapObject("Mountain_North_GlitteringBoulder", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 48, y: 13),
+                new ReflectableMapTile(layerName: "Buildings", x: 49, y: 13),
+
+                new ReflectableMapTile(layerName: "Buildings", x: 48, y: 12),
+                new ReflectableMapTile(layerName: "Buildings", x: 49, y: 12),
+
+                new ReflectableMapTile(layerName: "Buildings", x: 48, y: 11),
+                new ReflectableMapTile(layerName: "Buildings", x: 49, y: 11)
+            }),*/
             new ReflectableMapObject("Mountain_North_Wood_Plank_Long", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 61, y: 21) { Offset = new Vector2(0f, 1.65f) },
@@ -27,6 +76,72 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Buildings", x: 63, y: 21) { Offset = new Vector2(0f, 1.65f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 64, y: 21) { Offset = new Vector2(0f, 1.65f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 65, y: 21) { Offset = new Vector2(0f, 1.65f) }
+            }),
+            new ReflectableMapObject("Mountain_North_StaticFir_Tree_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 96, y: 5),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 4),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 3),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 3),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 3),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 2),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 2),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 2),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 1),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 1),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 1),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 0),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 0),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 0)
+            }),
+            new ReflectableMapObject("Mountain_North_StaticFir_Tree_3", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 101, y: 23),
+
+                new ReflectableMapTile(layerName: "Front", x: 101, y: 22),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 21),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 21),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 21),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 20),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 20),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 20),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 19),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 19),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 19),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 18),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 18),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 18)
+            }),
+            new ReflectableMapObject("Mountain_North_StaticPine_Tree_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 103, y: 32),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 31),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 30),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 30),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 30),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 29),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 29),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 29),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 28),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 28),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 28),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 27),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 27),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 27)
             }),
         };
     }

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/MountainMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/MountainMapTilePreset.cs
@@ -13,62 +13,13 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
         public override string MapName { get; } = "Mountain";
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
-            new ReflectableMapObject("Mountain_North_StaticPine_Tree_1", new List<ReflectableMapTile>()
+            new ReflectableMapObject("Mountain_North_Wood_Plank_Short", new List<ReflectableMapTile>()
             {
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 14),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 13),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 12),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 12),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 12),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 11),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 11),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 11),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 10),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 10),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 10),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 9),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 46, y: 9),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 47, y: 9)
+                new ReflectableMapTile(layerName: "Buildings", x: 46, y: 7) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 47, y: 7) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 48, y: 7) { Offset = new Vector2(0f, 1.6f) },
+                new ReflectableMapTile(layerName: "Buildings", x: 49, y: 7) { Offset = new Vector2(0f, 1.6f) },
             }),
-            new ReflectableMapObject("Mountain_North_StaticFir_Tree_1", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 53, y: 13),
-
-                new ReflectableMapTile(layerName: "Front", x: 53, y: 12),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 11),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 11),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 11),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 10),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 10),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 10),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 9),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 9),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 9),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 52, y: 8),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 53, y: 8),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 54, y: 8)
-            }),
-            //Silly me, looking for a cusror draw, but can it be done tho? (This does not work, the boulder is not a layer)
-            /*new ReflectableMapObject("Mountain_North_GlitteringBoulder", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 48, y: 13),
-                new ReflectableMapTile(layerName: "Buildings", x: 49, y: 13),
-
-                new ReflectableMapTile(layerName: "Buildings", x: 48, y: 12),
-                new ReflectableMapTile(layerName: "Buildings", x: 49, y: 12),
-
-                new ReflectableMapTile(layerName: "Buildings", x: 48, y: 11),
-                new ReflectableMapTile(layerName: "Buildings", x: 49, y: 11)
-            }),*/
             new ReflectableMapObject("Mountain_North_Wood_Plank_Long", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 61, y: 21) { Offset = new Vector2(0f, 1.65f) },
@@ -76,72 +27,6 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Buildings", x: 63, y: 21) { Offset = new Vector2(0f, 1.65f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 64, y: 21) { Offset = new Vector2(0f, 1.65f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 65, y: 21) { Offset = new Vector2(0f, 1.65f) }
-            }),
-            new ReflectableMapObject("Mountain_North_StaticFir_Tree_2", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 96, y: 5),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 4),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 3),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 3),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 3),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 2),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 2),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 2),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 1),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 1),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 1),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 95, y: 0),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 96, y: 0),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 97, y: 0)
-            }),
-            new ReflectableMapObject("Mountain_North_StaticFir_Tree_3", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 101, y: 23),
-
-                new ReflectableMapTile(layerName: "Front", x: 101, y: 22),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 21),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 21),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 21),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 20),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 20),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 20),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 19),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 19),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 19),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 100, y: 18),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 101, y: 18),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 18)
-            }),
-            new ReflectableMapObject("Mountain_North_StaticPine_Tree_2", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 103, y: 32),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 31),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 30),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 30),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 30),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 29),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 29),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 29),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 28),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 28),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 28),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 102, y: 27),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 103, y: 27),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 104, y: 27)
             }),
         };
     }

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/MountainMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/MountainMapTilePreset.cs
@@ -11,6 +11,8 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
     internal class MountainMapTilePreset : MapTilePresetTemplate
     {
         public override string MapName { get; } = "Mountain";
+        public override List<string> SkipWithModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
+
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
             new ReflectableMapObject("Mountain_North_Wood_Plank_Short", new List<ReflectableMapTile>()

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/TownMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/TownMapTilePreset.cs
@@ -13,6 +13,42 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
         public override string MapName { get; } = "Town";
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
+            new ReflectableMapObject("Town_SouthRiver_SpringTree_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 25, y: 97),
+                new ReflectableMapTile(layerName: "Buildings", x: 26, y: 97),
+                new ReflectableMapTile(layerName: "Buildings", x: 25, y: 96),
+                new ReflectableMapTile(layerName: "Buildings", x: 26, y: 96),
+
+                new ReflectableMapTile(layerName: "Front", x: 25, y: 95),
+                new ReflectableMapTile(layerName: "Front", x: 26, y: 95),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 23, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 94),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 23, y: 93),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 93),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 93),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 93),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 93),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 93),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 23, y: 92),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 92),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 92),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 92),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 92),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 92),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 91),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 91),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 91),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 91)
+            }),
             new ReflectableMapObject("Town_SouthRiver_Tree_1", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 43, y: 102),
@@ -42,6 +78,20 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "AlwaysFront", x: 43, y: 96),
                 new ReflectableMapTile(layerName: "AlwaysFront", x: 44, y: 96),
                 new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 96)
+            }),
+            new ReflectableMapObject("Town_EastRiver_StaticBush_1", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 58, y: 99),
+                new ReflectableMapTile(layerName: "Buildings", x: 59, y: 99),
+                new ReflectableMapTile(layerName: "Buildings", x: 60, y: 99),
+
+                new ReflectableMapTile(layerName: "Front", x: 58, y: 98),
+                new ReflectableMapTile(layerName: "Front", x: 59, y: 98),
+                new ReflectableMapTile(layerName: "Front", x: 60, y: 98),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 58, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 59, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 60, y: 97)
             }),
             new ReflectableMapObject("Town_EastRiver_Bridge_Under_1", new List<ReflectableMapTile>()
             {
@@ -76,6 +126,42 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Buildings", x: 81, y: 96) { Offset = new Vector2(0f, 1.6f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 82, y: 96) { Offset = new Vector2(0f, 1.6f) },
 
+            }),
+            new ReflectableMapObject("Town_SouthRiver_SpringTree_2", new List<ReflectableMapTile>()
+            {
+                new ReflectableMapTile(layerName: "Buildings", x: 88, y: 100),
+                new ReflectableMapTile(layerName: "Buildings", x: 89, y: 100),
+                new ReflectableMapTile(layerName: "Buildings", x: 88, y: 99),
+                new ReflectableMapTile(layerName: "Buildings", x: 89, y: 99),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 98),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 98),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 86, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 97),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 91, y: 97),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 86, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 96),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 91, y: 96),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 86, y: 95),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 95),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 95),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 95),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 95),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 91, y: 95),
+
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 94),
+                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 94)
             }),
             new ReflectableMapObject("Town_EastRiver_Bridge_Under_2", new List<ReflectableMapTile>()
             {

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/TownMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/TownMapTilePreset.cs
@@ -11,6 +11,8 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
     internal class TownMapTilePreset : MapTilePresetTemplate
     {
         public override string MapName { get; } = "Town";
+        public override List<string> SkipWithModIds { get; } = new List<string>() { "FlashShifter.StardewValleyExpandedCP" };
+
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
             new ReflectableMapObject("Town_SouthRiver_Tree_1", new List<ReflectableMapTile>()

--- a/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/TownMapTilePreset.cs
+++ b/DynamicReflections/Framework/Models/MapTilePresets/Vanilla/TownMapTilePreset.cs
@@ -13,42 +13,6 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
         public override string MapName { get; } = "Town";
         public override List<ReflectableMapObject> MapObjects { get; } = new List<ReflectableMapObject>()
         {
-            new ReflectableMapObject("Town_SouthRiver_SpringTree_1", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 25, y: 97),
-                new ReflectableMapTile(layerName: "Buildings", x: 26, y: 97),
-                new ReflectableMapTile(layerName: "Buildings", x: 25, y: 96),
-                new ReflectableMapTile(layerName: "Buildings", x: 26, y: 96),
-
-                new ReflectableMapTile(layerName: "Front", x: 25, y: 95),
-                new ReflectableMapTile(layerName: "Front", x: 26, y: 95),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 23, y: 94),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 94),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 94),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 94),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 94),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 94),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 23, y: 93),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 93),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 93),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 93),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 93),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 93),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 23, y: 92),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 92),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 92),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 92),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 92),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 28, y: 92),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 24, y: 91),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 25, y: 91),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 26, y: 91),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 27, y: 91)
-            }),
             new ReflectableMapObject("Town_SouthRiver_Tree_1", new List<ReflectableMapTile>()
             {
                 new ReflectableMapTile(layerName: "Buildings", x: 43, y: 102),
@@ -78,20 +42,6 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "AlwaysFront", x: 43, y: 96),
                 new ReflectableMapTile(layerName: "AlwaysFront", x: 44, y: 96),
                 new ReflectableMapTile(layerName: "AlwaysFront", x: 45, y: 96)
-            }),
-            new ReflectableMapObject("Town_EastRiver_StaticBush_1", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 58, y: 99),
-                new ReflectableMapTile(layerName: "Buildings", x: 59, y: 99),
-                new ReflectableMapTile(layerName: "Buildings", x: 60, y: 99),
-
-                new ReflectableMapTile(layerName: "Front", x: 58, y: 98),
-                new ReflectableMapTile(layerName: "Front", x: 59, y: 98),
-                new ReflectableMapTile(layerName: "Front", x: 60, y: 98),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 58, y: 97),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 59, y: 97),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 60, y: 97)
             }),
             new ReflectableMapObject("Town_EastRiver_Bridge_Under_1", new List<ReflectableMapTile>()
             {
@@ -126,42 +76,6 @@ namespace DynamicReflections.Framework.Models.MapTilePresets.Vanilla
                 new ReflectableMapTile(layerName: "Buildings", x: 81, y: 96) { Offset = new Vector2(0f, 1.6f) },
                 new ReflectableMapTile(layerName: "Buildings", x: 82, y: 96) { Offset = new Vector2(0f, 1.6f) },
 
-            }),
-            new ReflectableMapObject("Town_SouthRiver_SpringTree_2", new List<ReflectableMapTile>()
-            {
-                new ReflectableMapTile(layerName: "Buildings", x: 88, y: 100),
-                new ReflectableMapTile(layerName: "Buildings", x: 89, y: 100),
-                new ReflectableMapTile(layerName: "Buildings", x: 88, y: 99),
-                new ReflectableMapTile(layerName: "Buildings", x: 89, y: 99),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 98),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 98),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 86, y: 97),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 97),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 97),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 97),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 97),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 91, y: 97),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 86, y: 96),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 96),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 96),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 96),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 96),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 91, y: 96),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 86, y: 95),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 95),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 95),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 95),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 95),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 91, y: 95),
-
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 87, y: 94),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 88, y: 94),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 89, y: 94),
-                new ReflectableMapTile(layerName: "AlwaysFront", x: 90, y: 94)
             }),
             new ReflectableMapObject("Town_EastRiver_Bridge_Under_2", new List<ReflectableMapTile>()
             {


### PR DESCRIPTION
Made these SVE MapTilePresets, they are replacing the vanilla so you have to add them as SVE when you update the mod. This is for easy testing.

I mostly focused on adding the static trees, bushes, and misc tiles. I also enabled willys house and fixed it up in some places, the night market stayed mostly the same since sve doesn't replace that whole map. I have not made any additions to custom SVE locations or other festival variations. You should make one good quality run/check, I did double and triple checked everything is in place but finer edits would be nice especially with offsets. Oh would it be possible reflect the Glittering Boulder in the Mountains I tried but its not in a tiled layer since it's a mouse cursor draw.

I did notice two bugs, there is a noticeable pop in when moving up and down for the MapTiles only. You'll see it with all these reflected static trees. The other is to due with NPC refection placement moving above or below that of MapTiles this is relevant with the players y position, ex: players y pos is lower than Abigail's when shes at bridge results in she being rendered above the bridge reflection. If player is at same y pos she is rendered properly behind the bridge. 
Edit: Maybe adding a optional always in front property 

Btw I still have the issue of the disappearing night sky reflection on water, the night_sky_sheet.png not the shooting stars, I would love to fix this but I tried for a very long time and got nowhere and the fact that no one reported something similar yet scares me. I'll post a video showing it. [Youtube](https://youtu.be/ooSxe9-EaEU) 
Only if at one point I've visited an area would this happen doesn't matter which, if I go after that time period does it stay as it should.